### PR TITLE
Ability to set custom SDA and SCL pin. (Library can now be used on ESP32 series)

### DIFF
--- a/src/DFRobot_C4001.cpp
+++ b/src/DFRobot_C4001.cpp
@@ -751,9 +751,9 @@ DFRobot_C4001_I2C::DFRobot_C4001_I2C(TwoWire *pWire, uint8_t addr)
   uartI2CFlag = I2C_FLAG;
 }
 
-bool DFRobot_C4001_I2C::begin()
+bool DFRobot_C4001_I2C::begin(int sda /*=2*/, int scl/*=14*/)
 {
-  _pWire->begin();
+  _pWire->begin(sda, scl);
   _pWire->beginTransmission(_I2C_addr);
   if(_pWire->endTransmission() == 0){
     return true;

--- a/src/DFRobot_C4001.h
+++ b/src/DFRobot_C4001.h
@@ -420,7 +420,7 @@ private:
 class DFRobot_C4001_I2C:public DFRobot_C4001{
 public:
   DFRobot_C4001_I2C(TwoWire *pWire=&Wire, uint8_t addr = DEVICE_ADDR_0);
-  bool begin(void);
+  bool begin(int sda = 2, int scl = 14);
 protected:
   virtual void writeReg(uint8_t reg, uint8_t *data, uint8_t len);
   virtual int16_t readReg(uint8_t reg, uint8_t *data, uint8_t len);


### PR DESCRIPTION
`Wire.begin()` assumes pins 2 SDA, pin 14 SCL so we have set the same defaults for backwards compatibility.